### PR TITLE
Update full renormalizable, mass-independent SME model

### DIFF
--- a/deimos/models/liv/paper_plots/sidereal_P_oscillograms_final.py
+++ b/deimos/models/liv/paper_plots/sidereal_P_oscillograms_final.py
@@ -51,11 +51,12 @@ if __name__ == "__main__":
     # Define SME parameters
     sme_basis = "mass" # "mass" or "flavor"
     flavor_structure = np.array([0.0, 0.0, 1.0]) # diagonal elements of the SME matrix
-    direction_structure = np.array([0.0, 1.0, 0.0]) # x, y, z
+    a_eV_direction_structure = np.array([0.0, 0.0, 1.0, 0.0]) # t, x, y, z
+    c_direction_structure = np.array([[0.0, 1.0, 0.0, 0.0], [1.0, 0.0, 0.0, 0.0], [0.0, 0.0, 0.0, 0.0], [0.0, 0.0, 0.0, 0.0]]) # 2D structure 
     a_magnitude_eV = 0
     c_magnitude = 0
-    a_eV = np.array([a_magnitude_eV * n * np.diag(flavor_structure) for n in direction_structure])
-    ct = np.array([c_magnitude * n * np.diag(flavor_structure) for n in direction_structure])
+    a_eV = np.array([a_magnitude_eV * n * np.diag(flavor_structure) for n in a_eV_direction_structure])
+    ct = np.array([c_magnitude * n * np.diag(flavor_structure) for n in c_direction_structure])
     
     ### END OF SETUP ###
 

--- a/deimos/models/liv/paper_plots/sidereal_time_dependence_final.py
+++ b/deimos/models/liv/paper_plots/sidereal_time_dependence_final.py
@@ -25,11 +25,13 @@ def main():
     # Define SME parameters
     sme_basis = "mass" # "mass" or "flavor"
     flavor_structure = np.array([0.0, 0.0, 1.0]) # diagonal elements of the SME matrix
-    direction_structure = np.array([0.0, 1.0, 0.0]) # x, y, z
+    a_eV_direction_structure = np.array([0.0, 0.0, 1.0, 0.0]) # t, x, y, z
+    c_direction_structure = np.array([[0.0, 1.0, 0.0, 0.0], [1.0, 0.0, 0.0, 0.0], [0.0, 0.0, 0.0, 0.0], [0.0, 0.0, 0.0, 0.0]]) # 2D structure 
     a_magnitude_eV = 5e-14
     c_magnitude = 0
-    a_eV = np.array([a_magnitude_eV * n * np.diag(flavor_structure) for n in direction_structure])
-    ct = np.array([c_magnitude * n * np.diag(flavor_structure) for n in direction_structure])   
+    a_eV = np.array([a_magnitude_eV * n * np.diag(flavor_structure) for n in a_eV_direction_structure])
+    for n in c_direction_structure:
+        ct = np.array([c_magnitude * m * np.diag(flavor_structure) for m in n]).reshape(4, 4, 3, 3)
 
     # Create oscillation calculators
     kw = {"energy_nodes_GeV": E_GeV, "nusquids_variant": "sme"} if solver == "nusquids" else {}
@@ -74,12 +76,12 @@ def main():
         for time_index, time in enumerate(time_array):
             print(f"Progress: {dec_index}/{len(dec_deg)} {time_index}/{len(time_array)}", end="\r")
             P_ARCA_value, coszen_ARCA_value, _ = calculatorARCA.calc_osc_prob_sme(
-                basis=sme_basis, a_eV=a_eV, time=time, **calc_kw)
+                basis=sme_basis, a_eV=a_eV, c=ct, time=time, **calc_kw)
             cosz_ARCA[dec_index, time_index] = coszen_ARCA_value
             P_ARCA[:, dec_index, time_index] = P_ARCA_value[E_node, :]
 
         P_IC_value, coszen_IC_value, _ = calculatorIC.calc_osc_prob_sme(
-            basis=sme_basis, a_eV=a_eV, time=time_array[0], **calc_kw)
+            basis=sme_basis, a_eV=a_eV, c=ct, time=time_array[0], **calc_kw)
         cosz_IC[dec_index] = coszen_IC_value
         P_IC[:, dec_index] = P_IC_value[E_node, :]
 

--- a/deimos/models/liv/plot_sme_sidereal.py
+++ b/deimos/models/liv/plot_sme_sidereal.py
@@ -75,11 +75,16 @@ if __name__ == "__main__" :
     cases = collections.OrderedDict()
 
     a_magnitude_eV = 1e-13 # Overall strength of a component
-    # c_magnitude = 1e-26 # Overall strength of c component
-    flavor_structure = np.array([0., 0., 1.])    #TODO support off-diagonal
-    direction_structure = np.array([1., 0., 0.]) # Orient field in x direction     TODO define by RA/dec instead
-    a_eV = np.array([ a_magnitude_eV*n*np.diag(flavor_structure) for n in direction_structure ])##
+    c_magnitude = 0 # Overall strength of c component
     sme_basis = "mass"
+    flavor_structure = np.array([0.0, 0.0, 1.0]) # diagonal elements of the SME matrix
+    a_eV_direction_structure = np.array([0.0, 1.0, 0.0, 0.0]) # t, x, y, z
+    c_direction_structure = np.array([[0.0, 1.0, 0.0, 0.0], [1.0, 0.0, 0.0, 0.0], [0.0, 0.0, 0.0, 0.0], [0.0, 0.0, 0.0, 0.0]]) # 2D structure 
+
+    a_eV = np.array([a_magnitude_eV * n * np.diag(flavor_structure) for n in a_eV_direction_structure])
+    for n in c_direction_structure:
+        ct = np.array([c_magnitude * m * np.diag(flavor_structure) for m in n]).reshape(4, 4, 3, 3)
+
 
 
     #

--- a/deimos/wrapper/osc_calculator.py
+++ b/deimos/wrapper/osc_calculator.py
@@ -1099,7 +1099,6 @@ class OscCalculator(object) :
         basis=None,       # string: "mass" or "flavor"
         a_eV=None,        # 3 x Num_Nu x Num_nu
         c=None,           # 3 x Num_Nu x Num_nu
-        # e=None,           # 3 x Num_Nu x Num_nu   #TODO implement e term
         ra_rad=None,
         dec_rad=None,
     ) :
@@ -1116,17 +1115,13 @@ class OscCalculator(object) :
         assert basis in ["flavor", "mass"]
 
         if directional :   #TODO Maybe not relevant anymore? (Non-directional does currently not work in nuSQuIDS)
-            operator_shape = (3, self.num_neutrinos, self.num_neutrinos) # shape is (num spatial dims, N, N), where N is num neutrino states
             if a_eV is None: 
-                a_eV = np.zeros(operator_shape)
+                a_eV = np.zeros((4, self.num_neutrinos, self.num_neutrinos)) # shape is (num spatial dims, N, N), where N is num neutrino states
             if c is None:
-                c = np.zeros(operator_shape)
-            # if e is None :
-            #     e = np.zeros(operator_shape)
+                c = np.zeros((4, 4, self.num_neutrinos, self.num_neutrinos))
 
-            assert isinstance(a_eV, np.ndarray) and (a_eV.shape == operator_shape)
-            assert isinstance(c, np.ndarray) and (c.shape == operator_shape) 
-            # assert isinstance(e, np.ndarray) and (e.shape == operator_shape) 
+            assert isinstance(a_eV, np.ndarray) and (a_eV.shape == (4, self.num_neutrinos, self.num_neutrinos))
+            assert isinstance(c, np.ndarray) and (c.shape == (4, 4, self.num_neutrinos, self.num_neutrinos)) 
 
             assert (ra_rad is not None) and (dec_rad is not None), "Must provide ra and dec when using directional SME"
 
@@ -1160,7 +1155,6 @@ class OscCalculator(object) :
                     "basis" : basis,
                     "a_eV" : a_eV,
                     "c" : c,
-                    # "e": e,
                     "ra_rad" : ra_rad,
                     "dec_rad" : dec_rad,
                 }
@@ -1170,7 +1164,6 @@ class OscCalculator(object) :
                     "basis" : basis,
                     "a_eV" : a_eV,
                     "c" : c,
-                    # "e": e,
                 }
 
         else :
@@ -1395,7 +1388,6 @@ class OscCalculator(object) :
         basis=None,
         a_eV=None,
         c=None,
-        e=None,
         # Args to pass down to the standard osc prob calc
         **kw
     ) :
@@ -1443,8 +1435,6 @@ class OscCalculator(object) :
             assert basis is None
             assert a_eV is None
             assert c is None
-            assert e is None
-
 
         #
         # Loop over directions
@@ -1476,11 +1466,9 @@ class OscCalculator(object) :
                     basis=basis,
                     a_eV=a_eV,
                     c=c,
-                    # e=e,
                     ra_rad=ra_rad,
                     dec_rad=dec_rad,
                 )
-
 
             # 
             # Loop over times

--- a/deimos/wrapper/osc_calculator.py
+++ b/deimos/wrapper/osc_calculator.py
@@ -1144,9 +1144,17 @@ class OscCalculator(object) :
         #
 
         if self.solver == "nusquids" :
-            assert directional, "Istropic SME not implemented in nuSQuIDS yet"
             assert basis == "mass", "Only mass basis SME implemented in nuSQuIDS currently"
-            self.nusquids.Set_LIVCoefficient(a_eV, c, ra_rad, dec_rad)
+            if directional :
+                self.nusquids.Set_LIVCoefficient(a_eV, c, ra_rad, dec_rad)
+            else :
+                a_eV_isotropic= np.zeros((4, self.num_neutrinos, self.num_neutrinos))
+                c_isotropic = np.zeros((4, 4, self.num_neutrinos, self.num_neutrinos))
+                a_eV_isotropic[0] = a_eV
+                c_isotropic[0,0] = c
+                dec_rad = np.pi/2
+                ra_rad = 0
+                self.nusquids.Set_LIVCoefficient(a_eV_isotropic, c_isotropic, ra_rad, dec_rad)
 
         elif self.solver == "deimos" :
             if directional :


### PR DESCRIPTION
Changes: 

osc_calculator.py
- modify checks to allow all parameters of full renormalizable, mass-independent SME model to be set
- make isotropic model available in nuSQuIDS by only setting t/E components


density_matrix_osc_solver.py: 
- line 129: attempt at fixing issue with complex SME parameters
- rest: implementation of full renormalizable, mass-independent SME model

plotting scripts: 
- make compatible with implementation of full renormalizable, mass-independent SME model